### PR TITLE
feat: #47 user_page (schemas Free|Basic, repos, service, router, tidy…

### DIFF
--- a/br-general-python/app/api/__init__.py
+++ b/br-general-python/app/api/__init__.py
@@ -3,11 +3,17 @@
 from . import users, health, email, auth
 from fastapi import APIRouter
 from app.settings import settings
+from app.api import user_page
 
 api_router = APIRouter()
 api_router.include_router(health.router, prefix="/br-general/health", tags=["health"])
 api_router.include_router(auth.router, prefix="/br-general/auth", tags=["auth"])
 api_router.include_router(users.router, prefix="/br-general/users", tags=["users"])
+
+api_router.include_router(
+    user_page.router, prefix="/br-general/user_page", tags=["user page"]
+)
+
 # For production, disable email send and user create endpoints
 if settings.env_type != "prod":
     api_router.include_router(email.router, prefix="/br-general/email", tags=["email"])

--- a/br-general-python/app/api/deps.py
+++ b/br-general-python/app/api/deps.py
@@ -1,0 +1,25 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from app.services.auth_service import AuthService
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/login")
+auth_service = AuthService()
+
+
+async def current_user_id(token: str = Depends(oauth2_scheme)) -> str:
+    """Извлекает user_id из access_token"""
+    payload = auth_service.decode_token(token)
+    if not payload or payload.get("type") != "access":
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or expired token",
+        )
+
+    user_id = payload.get("sub")
+    if not user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token has no user ID",
+        )
+
+    return str(user_id)

--- a/br-general-python/app/api/user_page.py
+++ b/br-general-python/app/api/user_page.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, Depends
+from app.api.deps import current_user_id
+from app.schemas.user_page import UserPageResponse
+from app.services.user_page_service import UserPageService
+from app.repositories.user_repository import UserRepository
+from app.repositories.test_repository import TestRepo
+
+router = APIRouter(tags=["user page"])
+
+
+@router.get(
+    "",
+    response_model=UserPageResponse,
+    summary="Get current user's page",
+    operation_id="getUserPage",
+)
+async def get_user_page(user_id: str = Depends(current_user_id)):
+    service = UserPageService(UserRepository(), TestRepo())
+    return await service.build(user_id)

--- a/br-general-python/app/db/__init__.py
+++ b/br-general-python/app/db/__init__.py
@@ -2,4 +2,12 @@ from prisma import Prisma
 
 db = Prisma()
 
-__all__ = ["db"]
+
+async def connect():
+    if not db.is_connected():
+        await db.connect()
+
+
+async def disconnect():
+    if db.is_connected():
+        await db.disconnect()

--- a/br-general-python/app/main.py
+++ b/br-general-python/app/main.py
@@ -1,19 +1,28 @@
 from contextlib import asynccontextmanager
-
 from fastapi import FastAPI
 
 from app.db import db
 from app.api import api_router
 
 
+# 👇 даёт короткие и понятные имена операциям в Swagger (operationId)
+def generate_operation_id(route):
+    # пример: тег "User Page" + имя функции → "User_Page_get_user_page"
+    tag = (route.tags[0] if route.tags else "api").replace(" ", "_")
+    name = route.name or route.path.replace("/", "_")
+    return f"{tag}_{name}"
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # startup
     await db.connect()
     yield
-    # shutdown
     await db.disconnect()
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(
+    lifespan=lifespan,
+    generate_unique_id_function=generate_operation_id,  # 👈 ключевая строка
+)
+
 app.include_router(api_router)

--- a/br-general-python/app/repositories/test_repository.py
+++ b/br-general-python/app/repositories/test_repository.py
@@ -1,0 +1,11 @@
+from app.db import db
+
+
+class TestRepo:
+    async def list_sessions_with_titles(self, user_id: str):
+        sessions = await db.testsession.find_many(
+            where={"userId": user_id},
+            order={"createdAt": "desc"},
+            include={"test": True},
+        )
+        return sessions

--- a/br-general-python/app/repositories/user_repository.py
+++ b/br-general-python/app/repositories/user_repository.py
@@ -1,11 +1,17 @@
-class UserRepository:
-    async def get_by_email(self, db, email: str):
-        return await db.user.find_unique(where={"email": email})
+from datetime import datetime, timezone
+from app.db import db
 
-    async def create_user(self, db, email: str, hashed_password: str):
-        return await db.user.create(
-            data={
-                "email": email,
-                "hashed_password": hashed_password,
-            }
+
+class UserRepository:
+    async def get_by_id(self, user_id: str):
+        # базовые поля пользователя (без подписок — хватит для email/name/role)
+        return await db.user.find_unique(
+            where={"id": user_id},
+        )
+
+    async def get_active_subscription(self, user_id: str):
+        now = datetime.now(timezone.utc)
+        return await db.subscription.find_first(
+            where={"userId": user_id, "endsAt": {"gt": now}},
+            order={"endsAt": "desc"},
         )

--- a/br-general-python/app/schemas/user.py
+++ b/br-general-python/app/schemas/user.py
@@ -1,9 +1,10 @@
 from pydantic import BaseModel, EmailStr
 
 
-class UserCreate(BaseModel):
+class UserCreate(BaseModel, EmailStr):
     email: str
     password: str
+    name: str | None = None
 
 
 class UserResponse(BaseModel):

--- a/br-general-python/app/schemas/user_page.py
+++ b/br-general-python/app/schemas/user_page.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import Literal, List, Union
+from pydantic import BaseModel
+
+
+class PassedTestSummary(BaseModel):
+    name: str
+    times_passed: int
+
+
+class BaseUserInfo(BaseModel):
+    email: str
+    name: str
+    role: Literal["PATIENT", "DOCTOR"]
+
+
+class FreeUserPage(BaseUserInfo):
+    plan: Literal["FREE"]
+    consultations_left: int
+    passed_tests: List[PassedTestSummary]
+
+
+class BasicUserPage(BaseUserInfo):
+    plan: Literal["BASIC"]
+    subscription_ends_at: datetime
+    consultations_left: int
+    passed_tests: List[PassedTestSummary]
+
+
+UserPageResponse = Union[FreeUserPage, BasicUserPage]

--- a/br-general-python/app/services/user_page_service.py
+++ b/br-general-python/app/services/user_page_service.py
@@ -1,0 +1,59 @@
+from collections import Counter
+from app.repositories.user_repository import UserRepository
+from app.repositories.test_repository import TestRepo
+from app.schemas.user_page import (
+    FreeUserPage,
+    BasicUserPage,
+    PassedTestSummary,
+    UserPageResponse,
+)
+
+
+class UserPageService:
+    def __init__(self, user_repo: UserRepository, test_repo: TestRepo):
+        self.user_repo = user_repo
+        self.test_repo = test_repo
+
+    async def build(self, user_id: str) -> UserPageResponse:
+        user = await self.user_repo.get_by_id(user_id)
+        if not user:
+            from fastapi import HTTPException
+
+            raise HTTPException(status_code=404, detail="User not found")
+
+        # 1) Активная подписка (Basic)
+        sub = await self.user_repo.get_active_subscription(user_id)
+
+        # 2) Сводка по завершённым тестам
+        sessions = await self.test_repo.list_sessions_with_titles(user_id)
+        finished_titles = [s.test.title for s in sessions if s.finishedAt and s.test]
+        counts = Counter(finished_titles)
+        passed_tests = [
+            PassedTestSummary(name=k, times_passed=v) for k, v in counts.items()
+        ]
+
+        # 3) Возвращаем либо BASIC, либо FREE
+        role_str = user.role.name if hasattr(user.role, "name") else str(user.role)
+
+        if sub:  # BASIC
+            included = int(sub.consultationsIncluded or 0)
+            used = int(sub.consultationsUsed or 0)
+            return BasicUserPage(
+                email=user.email,
+                name=user.name,
+                role=role_str,
+                plan="BASIC",
+                subscription_ends_at=sub.endsAt,
+                consultations_left=max(0, included - used),
+                passed_tests=passed_tests,
+            )
+
+        # FREE (активной подписки нет)
+        return FreeUserPage(
+            email=user.email,
+            name=user.name,
+            role=role_str,
+            plan="FREE",
+            consultations_left=0,
+            passed_tests=passed_tests,
+        )

--- a/br-general-python/prisma/schema.prisma
+++ b/br-general-python/prisma/schema.prisma
@@ -9,13 +9,32 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum QuestionType {
+  RADIO
+  CHECKBOX
+  TEXT
+}
+
+enum Role {
+  PATIENT
+  DOCTOR
+}
+
+enum Plan {
+  FREE
+  BASIC
+}
+
 model User {
-  id              Int           @id @default(autoincrement())
-  email           String        @unique
+  id              String   @id @default(cuid())
+  email           String   @unique
   hashed_password String
-  name            String?
-  createdAt       DateTime      @default(now())
-  sessions        TestSession[]
+  name            String
+  role            Role     @default(PATIENT)
+  createdAt       DateTime @default(now())
+
+  sessions      TestSession[]
+  subscriptions Subscription[]
 }
 
 model Test {
@@ -34,7 +53,6 @@ model Question {
   text      String
   type      QuestionType
   options   AnswerOption[]
-  // Добавляем чтобы было дерево вопросов: тут указываем, какой вопрос показать после текущего
   nextYesId String?
   nextNoId  String?
   createdAt DateTime       @default(now())
@@ -46,7 +64,7 @@ model AnswerOption {
   question   Question      @relation(fields: [questionId], references: [id], onDelete: Cascade)
   questionId String
   text       String
-  isCorrect  Boolean? // тру для автопроверки
+  isCorrect  Boolean
   createdAt  DateTime      @default(now())
   answers    GivenAnswer[]
 }
@@ -56,7 +74,7 @@ model TestSession {
   test       Test          @relation(fields: [testId], references: [id], onDelete: Cascade)
   testId     String
   user       User          @relation(fields: [userId], references: [id], onDelete: Cascade)
-  userId     Int
+  userId     String
   createdAt  DateTime      @default(now())
   finishedAt DateTime?
   answers    GivenAnswer[]
@@ -74,22 +92,26 @@ model GivenAnswer {
   createdAt      DateTime      @default(now())
 }
 
-enum QuestionType {
-  RADIO
-  CHECKBOX
-  TEXT
-}
-
 model EmailLog {
   id        String   @id @default(cuid())
   to        String
   subject   String
-  template  String?
-  // optional: store raw body or rendered HTML
-  body      String?
-  // e.g. "SENT", "FAILED"
-  status    String
-  // error message if failed
+  template  String? // optional: store raw body or rendered HTML
+  body      String? // e.g. "SENT", "FAILED"
+  status    String // error message if failed
   error     String?
   createdAt DateTime @default(now())
+}
+
+model Subscription {
+  id                    String   @id @default(cuid())
+  userId                String
+  plan                  Plan     @default(FREE)
+  startedAt             DateTime @default(now())
+  endsAt                DateTime
+  consultationsIncluded Int      @default(0)
+  consultationsUsed     Int      @default(0)
+  createdAt             DateTime @default(now())
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: Cascade)
 }


### PR DESCRIPTION
Added a new /br-general/user_page endpoint that returns user info together with their active subscription and test stats.
Supports both FREE and BASIC users (oneOf schema in Swagger).
Cleaned up router tags, added nice operationId, and made the docs look neat again